### PR TITLE
create /home/omero/.bashrc if it does not exist

### DIFF
--- a/tasks/omero-user.yml
+++ b/tasks/omero-user.yml
@@ -34,6 +34,7 @@
     regexp: "{{ omero_server_symlink }}"
     line: "export PATH={{ omero_serverdir }}/{{ omero_server_symlink }}/bin:$PATH"
     state: present
+    create: yes
 
 - name: omero | set JAVA_OPTS
   become: yes


### PR DESCRIPTION
> necessary to make training-server.yml run on CentOS 7 in (Vagrant box 1611.01 for VirtualBox).

Migrated from https://github.com/openmicroscopy/infrastructure/pull/244