### PR TITLE
Add flag to disable database init/upgrades (IDR-0.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This defaults to `latest`, but due to the broken registry a proper upgrade check
 You are advised to change this to an actual release version.
 - `omero_server_upgrade`: Upgrade OMERO.server if the current version does not match `omero_server_release`.
   This is a workaround for the inability to check for the latest version when `omero_server_release: latest`.
-  It may be removed in future.
+  At present this will skip an available upgrade if `False` but in future this will be changed to fail if the currently installed version does not match `omero_server_release`.
 - `omero_server_ice_version`: The ice version.
 
 Database connection parameters and initialisation.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Database connection parameters and initialisation.
 - `omero_server_dbpassword`: Database password
 - `omero_server_rootpassword`: OMERO root password, default `omero`.
   This is only used when initialising a new database.
+- `omero_server_database_manage`: If `True` initialise or upgrade the OMERO database as required
 
 OMERO.server configuration.
 - `omero_server_config_set`: A dictionary of `config-key: value` which will be used for the initial OMERO.server configuration, default empty.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Unstable features
 Variables :
 - `omero_server_datadir_chown`: Recursively set the owner on the OMERO data directory, use if the directory has been copied with an incorrect owner, default `False`
 - `omero_server_database_manage`: Initialise or upgrade the OMERO database if required, default `True`, if `False` the database will not be modified and all `omero_server_db*` will be ignored (`omero.db.*` OMERO configuration parameters will not be updated with the corresponding `omero_server_db*` values)
+- `omero_server_datadir_manage`: Initialise of modify the top level of OMERO data directories, deafult `True`, if `False` no data directories will be created or modified, and the `omero.data.dir` configuration parameter will not be set
 - `omero_server_systemd_start`: Automatically enable and start/restart systemd omero-server service, default `True`.
   This is intended for use in server images where installation may be separate from configuration and execution.
 - `omero_server_always_reset_config`: Clear the existing configuration before regenerating, default `True`.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Database connection parameters and initialisation.
 - `omero_server_dbpassword`: Database password
 - `omero_server_rootpassword`: OMERO root password, default `omero`.
   This is only used when initialising a new database.
-- `omero_server_database_manage`: If `True` initialise or upgrade the OMERO database as required
 
 OMERO.server configuration.
 - `omero_server_config_set`: A dictionary of `config-key: value` which will be used for the initial OMERO.server configuration, default empty.
@@ -63,6 +62,7 @@ Unstable features
 
 Variables :
 - `omero_server_datadir_chown`: Recursively set the owner on the OMERO data directory, use if the directory has been copied with an incorrect owner, default `False`
+- `omero_server_database_manage`: Initialise or upgrade the OMERO database if required, default `True`, if `False` the database will not be modified and all `omero_server_db*` will be ignored (`omero.db.*` OMERO configuration parameters will not be updated with the corresponding `omero_server_db*` values)
 - `omero_server_systemd_start`: Automatically enable and start/restart systemd omero-server service, default `True`.
   This is intended for use in server images where installation may be separate from configuration and execution.
 - `omero_server_always_reset_config`: Clear the existing configuration before regenerating, default `True`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -92,6 +92,11 @@ omero_server_omego_verbosity: "-qq"
 # Additional omego aguments passed to upgrade or install
 omero_server_omego_additional_args: ""
 
+# DEVELOPMENT: Operator for comparing current-version against
+# omero_server_release, e.g. '!='. Default is to upgrade when
+# current-version < omero_server_release
+omero_server_checkupgrade_comparator: '<'
+
 
 omero_server_omego_options: >
   --release {{ omero_server_release }}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,7 +74,7 @@ omero_server_always_reset_config: True
 # DEVELOPMENT: Automatically start systemd omero
 omero_server_systemd_start: True
 
-# DEVELOPMENT: Automatically init/upgrade the OMERO database
+# DEVELOPMENT: Automatically init/upgrade and configure the OMERO database
 omero_server_database_manage: True
 
 # Base directory for the server installation

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,9 +20,6 @@ omero_server_dbpassword: omero
 # OMERO root password
 omero_server_rootpassword: omero
 
-# Manage the OMERO database?
-omero_server_database_manage: True
-
 # Dictionary of additional OMERO configuration options
 omero_server_config_set: {}
 
@@ -76,6 +73,9 @@ omero_server_always_reset_config: True
 
 # DEVELOPMENT: Automatically start systemd omero
 omero_server_systemd_start: True
+
+# DEVELOPMENT: Automatically init/upgrade the OMERO database
+omero_server_database_manage: True
 
 # Base directory for the server installation
 omero_server_basedir: "{{ omero_common_basedir }}/server"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,6 +77,9 @@ omero_server_systemd_start: True
 # DEVELOPMENT: Automatically init/upgrade and configure the OMERO database
 omero_server_database_manage: True
 
+# DEVELOPMENT: Automatically create and configure OMERO data directories
+omero_server_datadir_manage: True
+
 # Base directory for the server installation
 omero_server_basedir: "{{ omero_common_basedir }}/server"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -115,3 +115,5 @@ omero_server_omego_db_options: >
   --dbuser {{ omero_server_dbuser | quote }}
   --dbname {{ omero_server_dbname | quote }}
   --dbpass {{ omero_server_dbpassword | quote  }}
+  {{ omero_server_database_manage | ternary('--initdb', '') }}
+  {{ omero_server_database_manage | ternary('--upgradedb', '') }}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,9 @@ omero_server_dbpassword: omero
 # OMERO root password
 omero_server_rootpassword: omero
 
+# Manage the OMERO database?
+omero_server_database_manage: True
+
 # Dictionary of additional OMERO configuration options
 omero_server_config_set: {}
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -115,5 +115,4 @@ omero_server_omego_db_options: >
   --dbuser {{ omero_server_dbuser | quote }}
   --dbname {{ omero_server_dbname | quote }}
   --dbpass {{ omero_server_dbpassword | quote  }}
-  {{ omero_server_database_manage | ternary('--initdb', '') }}
-  {{ omero_server_database_manage | ternary('--upgradedb', '') }}
+  {{ omero_server_database_manage | ternary('--managedb', '') }}

--- a/molecule.yml
+++ b/molecule.yml
@@ -42,14 +42,13 @@ docker:
 ansible:
   host_vars:
     omero-server-olddep:
-      # Use the 5.2 line due to https://github.com/ome/omego/pull/101
-      omero_server_release: "5.2"
       omero_server_ice_version: "3.5"
       postgresql_version: "9.4"
 
     omero-server-newdep:
       omero_server_ice_version: "3.6"
       postgresql_version: "9.6"
+      omero_server_upgrade: True
 
   group_vars:
     docker-hosts:

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,5 +1,5 @@
 ---
-
+# Install 5.2 on both omero-server-olddep and omero-server-newdep
 - hosts: all
   roles:
 
@@ -18,6 +18,7 @@
           - plate
           - project
           - dataset
+      omero_server_release: "5.2"
 
   tasks:
     - name: additional config file
@@ -27,6 +28,27 @@
         dest: /opt/omero/server/config/molecule-additional-config.omero
       notify:
       - restart omero-server
+
+
+# Attempt to upgrade to 5.3
+# omero_server_upgrade is defined in molecule.yml host_vars so:
+# - omero-server-newdep: upgraded
+# - omero-server-olddep: unchanged
+- hosts: all
+  roles:
+
+    - role: ansible-role-omero-server
+      omero_server_system_managedrepo_group: importer
+      omero_server_config_set:
+        omero.client.ui.tree.type_order:
+          - screen
+          - plate
+          - project
+          - dataset
+      # Ideally this would be set to the default `latest`, but we don't
+      # have an easy way to check whether the currently installed version
+      # is the latest
+      omero_server_release: "5.3"
 
 
 # Additional tasks for setting up tests

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
 - include: omero-user.yml
 
 - include: omero-datadir.yml
+  when: omero_server_datadir_manage
 
 - include: omero-configfiles.yml
 

--- a/tasks/omero-install.yml
+++ b/tasks/omero-install.yml
@@ -103,7 +103,13 @@
   when: (omero_server_database_backupdir | default(None)) and omero_server_upgrade and omero_server_update_needed
 
 # Upgrade
-
+# TODO: Currently this silently skips the upgrade if
+# omero_server_update_needed: True and omero_server_upgrade: False
+# since there isn't an easy way to check whether the current version is
+# the same as latest.
+# Once this check is implemented this will change to failing immediately
+# since if you want to pin a particular version you can set
+# omero_server_release: X.Y.Z
 - name: omero server | upgrade
   become: yes
   become_user: "{{ omero_server_system_user }}"

--- a/tasks/omero-install.yml
+++ b/tasks/omero-install.yml
@@ -56,7 +56,8 @@
     omero_server_update_needed: >
       {{
         omero_server_symlink_st.stat.exists and
-        (omero_server_version.stdout | version_compare(omero_server_release, '<'))
+        (omero_server_version.stdout | version_compare(
+           omero_server_release, omero_server_checkupgrade_comparator))
       }}
 #  ignore_errors: yes
 #

--- a/tasks/omero-install.yml
+++ b/tasks/omero-install.yml
@@ -36,7 +36,6 @@
     {{ omero_server_omego_options }}
     {{ omero_server_omego_db_options }}
     --rootpass {{ omero_server_rootpassword | quote }}
-    {{ omero_server_database_manage | ternary('--initdb', '') }}
   args:
     chdir: "{{ omero_server_basedir }}"
     creates: "{{ omero_server_basedir }}/{{ omero_server_symlink }}"
@@ -119,7 +118,6 @@
     upgrade
     {{ omero_server_omego_options }}
     {{ omero_server_omego_db_options }}
-    {{ omero_server_database_manage | ternary('--upgradedb', '') }}
   args:
     chdir: "{{ omero_server_basedir }}"
   # I have no idea why testing the variables directly doesn't work:

--- a/tasks/omero-install.yml
+++ b/tasks/omero-install.yml
@@ -97,7 +97,7 @@
     upgrade
     {{ omero_server_omego_options }}
     {{ omero_server_omego_db_options }}
-    --upgradedb
+    {{ omero_server_database_manage | ternary('--upgradedb', '') }}
   args:
     chdir: "{{ omero_server_basedir }}"
   when: omero_server_upgrade and omero_server_update_needed

--- a/tasks/omero-install.yml
+++ b/tasks/omero-install.yml
@@ -36,7 +36,7 @@
     {{ omero_server_omego_options }}
     {{ omero_server_omego_db_options }}
     --rootpass {{ omero_server_rootpassword | quote }}
-    --initdb
+    {{ omero_server_database_manage | ternary('--initdb', '') }}
   args:
     chdir: "{{ omero_server_basedir }}"
     creates: "{{ omero_server_basedir }}/{{ omero_server_symlink }}"

--- a/tasks/omero-install.yml
+++ b/tasks/omero-install.yml
@@ -115,7 +115,7 @@
   become_user: "{{ omero_server_system_user }}"
   command: >
     {{ omero_server_omego }}
-    upgrade
+    install --upgrade
     {{ omero_server_omego_options }}
     {{ omero_server_omego_db_options }}
   args:

--- a/tasks/omero-install.yml
+++ b/tasks/omero-install.yml
@@ -51,18 +51,33 @@
 
 - name: omero server | checkupgrade
   set_fact:
-    omero_server_update_needed: True
-  when: omero_server_symlink_st.stat.exists and (omero_server_version.stdout | regex_replace('^([^-]+).*', '\\1')) != omero_server_release
-  ignore_errors: yes
-
-- name: omero server | checkupgrade
-  set_fact:
-    omero_server_update_needed: False
-  when: omero_server_update_needed is not defined
+    # Experimentation shows "5.3.2 | version_compare('latest', '<')" is False
+    # so this should work as expected
+    omero_server_update_needed: >
+      {{
+        omero_server_symlink_st.stat.exists and
+        (omero_server_version.stdout | version_compare(omero_server_release, '<'))
+      }}
+#  ignore_errors: yes
+#
+#- name: omero server | checkupgrade
+#  set_fact:
+#    omero_server_update_needed: False
+#  when: omero_server_update_needed is not defined
 
 - debug:
-    msg: "Upgrade needed: {{ omero_server_version.stdout | regex_replace('^([^-]+).*', '\\1') }} -> {{ omero_server_release }}"
+    msg: "Upgrade needed: {{ omero_server_version.stdout }} -> {{ omero_server_release }}"
   when: omero_server_update_needed
+
+# TODO: Ideally we'd just use
+# `when: omero_server_upgrade and omero_server_update_needed`
+# but there seems to be a problem with the `omero server | upgrade` task which
+# always runs when `omero_server_upgrade: True` regardless of the value of
+# `omero_server_update_needed`, so use this additional fact as a workaround
+# until it can be investigated further
+- name: omero server | set upgrade flag
+  set_fact:
+    _omero_server_execute_upgrade: "{{ omero_server_upgrade and omero_server_update_needed }}"
 
 # Backup database
 
@@ -100,7 +115,9 @@
     {{ omero_server_database_manage | ternary('--upgradedb', '') }}
   args:
     chdir: "{{ omero_server_basedir }}"
-  when: omero_server_upgrade and omero_server_update_needed
+  # I have no idea why testing the variables directly doesn't work:
+  #when: omero_server_upgrade and omero_server_update_needed
+  when: _omero_server_execute_upgrade
   notify:
   - omero-server rewrite omero-server configuration
   - omero-server restart omero-server

--- a/templates/00-omero-server-omero.j2
+++ b/templates/00-omero-server-omero.j2
@@ -4,11 +4,13 @@
 config drop default
 {% endif %}
 
+{% if omero_server_database_manage %}
 config set omero.db.host {{ omero_server_dbhost | quote }}
 config set omero.db.user {{ omero_server_dbuser | quote }}
 config set omero.db.name {{ omero_server_dbname | quote }}
 config set omero.db.pass {{ omero_server_dbpassword | quote }}
 config set omero.data.dir {{ omero_server_datadir | quote }}
+{% endif %}
 
 # Additional custom options
 {% for key in omero_server_config_set %}

--- a/templates/00-omero-server-omero.j2
+++ b/templates/00-omero-server-omero.j2
@@ -11,7 +11,9 @@ config set omero.db.name {{ omero_server_dbname | quote }}
 config set omero.db.pass {{ omero_server_dbpassword | quote }}
 {% endif %}
 
+{% if omero_server_datadir_manage %}
 config set omero.data.dir {{ omero_server_datadir | quote }}
+{% endif %}
 
 # Additional custom options
 {% for key in omero_server_config_set %}

--- a/templates/00-omero-server-omero.j2
+++ b/templates/00-omero-server-omero.j2
@@ -9,8 +9,9 @@ config set omero.db.host {{ omero_server_dbhost | quote }}
 config set omero.db.user {{ omero_server_dbuser | quote }}
 config set omero.db.name {{ omero_server_dbname | quote }}
 config set omero.db.pass {{ omero_server_dbpassword | quote }}
-config set omero.data.dir {{ omero_server_datadir | quote }}
 {% endif %}
+
+config set omero.data.dir {{ omero_server_datadir | quote }}
 
 # Additional custom options
 {% for key in omero_server_config_set %}

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,6 +1,5 @@
 - src: openmicroscopy.omero-common
-- name: openmicroscopy.omego
-  src:  https://github.com/openmicroscopy/ansible-role-omego.git
+- src: openmicroscopy.omego
 - src: openmicroscopy.basedeps
 - src: openmicroscopy.java
 - src: openmicroscopy.omero-python-deps

--- a/tests/test_newdep.py
+++ b/tests/test_newdep.py
@@ -10,7 +10,7 @@ OMERO = '/opt/omero/server/OMERO.server/bin/omero'
 def test_omero_version(Command, Sudo):
     with Sudo('data-importer'):
         ver = Command.check_output("%s version" % OMERO)
-    assert re.match('\d+\.\d+\.\d+-ice36-', ver)
+    assert re.match('5\.3\.\d+-ice36-', ver)
 
 
 def test_postgres_version(Command):

--- a/tests/test_olddep.py
+++ b/tests/test_olddep.py
@@ -10,7 +10,7 @@ OMERO = '/opt/omero/server/OMERO.server/bin/omero'
 def test_omero_version(Command, Sudo):
     with Sudo('data-importer'):
         ver = Command.check_output("%s version" % OMERO)
-    assert re.match('\d+\.\d+\.\d+-ice35-', ver)
+    assert re.match('5\.2\.\d+-ice35-', ver)
 
 
 def test_postgres_version(Command):


### PR DESCRIPTION
This is useful for building images where the database is only available at runtime, not installation, for example when building Docker images.

See https://github.com/openmicroscopy/omero-grid-docker/pull/8#issuecomment-303155866 and the referenced commits for an example.

## Updated 2017-05-25

There was some problems in the upgrade version checks. This PR now adds some tests and a fix. This also introduces some minor improvements (though arguably they're changes in behaviour):
- Partial version comparisons are supported, so for example `omero_server_release: "5.2", omero_server_upgrade: True` will only upgrade if your server is `5.1.*`, previously only full 3-digit versions were supported. However, this means downgrades are no longer supported (e.g. 5.3.2 -> 5.3.0) since the comparison is `current-installed-version < omero_server_release` instead of `==`

I've also changed `omero_server_database_manage` to be a development/unstable feature, to give more time for deciding on semantics for setting `omero.db.*` options in the config file when `omero_server_database_manage: False`

## Updated 2017-06-12
- Added `omero_server_datadir_manage` flag
- Modified db handling:
--depends-on https://github.com/ome/omego/pull/104


Proposed tag: 2.0.0-m2