### PR TITLE
Allow alternative location for BioFormatsCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ OMERO.server configuration.
 
 OMERO system user, group, permissions, and data directory.
 You may need to change these for in-place imports.
+Directory paths must not have a trailing `/`
 - `omero_server_system_user`: OMERO.server system user, default `omero-server`.
 - `omero_server_system_uid`: OMERO system user ID (default automatic)
 - `omero_server_system_umask`: OMERO system user umask, may need to be changed for in-place imports

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ You may need to change these for in-place imports.
 - `omero_server_datadir_managedrepo_mode`: Permissions for OMERO `ManagedRepository`
 - `omero_server_datadir`: OMERO data directory, default `/OMERO`
 - `omero_server_datadir_managedrepo`: OMERO ManagedRepository directory
+- `omero_server_datadir_bioformatscache`: OMERO BioFormatsCache directory, a symlink `{omero_server_datadir}/BioFormatsCache` will be created if not the default
 
 OMERO.server systemd configuration.
 - `omero_server_systemd_setup`: Create and start the `omero-server` systemd service, default `True`

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ OMERO.server configuration.
 
 OMERO system user, group, permissions, and data directory.
 You may need to change these for in-place imports.
-Directory paths must not have a trailing `/`
 - `omero_server_system_user`: OMERO.server system user, default `omero-server`.
 - `omero_server_system_uid`: OMERO system user ID (default automatic)
 - `omero_server_system_umask`: OMERO system user umask, may need to be changed for in-place imports
@@ -49,7 +48,6 @@ Directory paths must not have a trailing `/`
 - `omero_server_datadir_managedrepo_mode`: Permissions for OMERO `ManagedRepository`
 - `omero_server_datadir`: OMERO data directory, default `/OMERO`
 - `omero_server_datadir_managedrepo`: OMERO ManagedRepository directory
-- `omero_server_datadir_bioformatscache`: OMERO BioFormatsCache directory, a symlink `{omero_server_datadir}/BioFormatsCache` will be created if not the default
 
 OMERO.server systemd configuration.
 - `omero_server_systemd_setup`: Create and start the `omero-server` systemd service, default `True`
@@ -64,6 +62,8 @@ Unstable features
 
 Variables :
 - `omero_server_datadir_chown`: Recursively set the owner on the OMERO data directory, use if the directory has been copied with an incorrect owner, default `False`
+- `omero_server_datadir_bioformatscache`: OMERO BioFormatsCache directory, a symlink `{omero_server_datadir}/BioFormatsCache` will be created if not the default.
+  Directory paths must not have a trailing `/`.
 - `omero_server_database_manage`: Initialise or upgrade the OMERO database if required, default `True`, if `False` the database will not be modified and all `omero_server_db*` will be ignored (`omero.db.*` OMERO configuration parameters will not be updated with the corresponding `omero_server_db*` values)
 - `omero_server_datadir_manage`: Initialise of modify the top level of OMERO data directories, deafult `True`, if `False` no data directories will be created or modified, and the `omero.data.dir` configuration parameter will not be set
 - `omero_server_systemd_start`: Automatically enable and start/restart systemd omero-server service, default `True`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,9 +41,6 @@ omero_server_datadir: /OMERO
 # OMERO ManagedRepository directory
 omero_server_datadir_managedrepo: "{{ omero_server_datadir }}/ManagedRepository"
 
-# OMERO BioFormatsCache directory
-omero_server_datadir_bioformatscache: "{{ omero_server_datadir }}/BioFormatsCache"
-
 # Permissions for OMERO data directories apart from ManagedRepository
 omero_server_datadir_mode: "u=rwX,g=rX,o=rX"
 
@@ -70,6 +67,9 @@ omero_server_database_backupdir: # "{{ omero_server_basedir }}/backups"
 # Recursively set the owner on the OMERO data directory, use if the directory
 # has been copied with an incorrect owner
 omero_server_datadir_chown: False
+
+# OMERO BioFormatsCache directory
+omero_server_datadir_bioformatscache: "{{ omero_server_datadir }}/BioFormatsCache"
 
 # DEVELOPMENT: If True clear the existing configuration before regenerating
 omero_server_always_reset_config: True

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,9 @@ omero_server_datadir: /OMERO
 # OMERO ManagedRepository directory
 omero_server_datadir_managedrepo: "{{ omero_server_datadir }}/ManagedRepository"
 
+# OMERO BioFormatsCache directory
+omero_server_datadir_bioformatscache: "{{ omero_server_datadir }}/BioFormatsCache"
+
 # Permissions for OMERO data directories apart from ManagedRepository
 omero_server_datadir_mode: "u=rwX,g=rX,o=rX"
 

--- a/tasks/omero-datadir.yml
+++ b/tasks/omero-datadir.yml
@@ -41,7 +41,7 @@
     path: "{{ omero_server_datadir }}/BioFormatsCache"
     state: link
     force: yes
-  when: '"omero_server_datadir_bioformatscache" != (omero_server_datadir + "/BioFormatsCache")'
+  when: 'omero_server_datadir_bioformatscache != (omero_server_datadir + "/BioFormatsCache")'
 
 - name: omero server | create omero ManagedRepository
   become: yes

--- a/tasks/omero-datadir.yml
+++ b/tasks/omero-datadir.yml
@@ -19,12 +19,29 @@
     recurse: "{{ omero_server_datadir_chown }}"
     state: directory
   with_items:
-  - BioFormatsCache
   - Files
   - Thumbnails
   - DropBox
   - FullText
   - Pixels
+
+- name: omero server | create omero BioFormatsCache
+  become: yes
+  file:
+    owner: "{{ omero_server_system_user }}"
+    mode: "{{ omero_server_datadir_mode }}"
+    path: "{{ omero_server_datadir_bioformatscache }}"
+    recurse: "{{ omero_server_datadir_chown }}"
+    state: directory
+
+- name: omero server | create omero BioFormatsCache symlink
+  become: yes
+  file:
+    src: "{{ omero_server_datadir_bioformatscache }}"
+    path: "{{ omero_server_datadir }}/BioFormatsCache"
+    state: link
+    force: yes
+  when: '"omero_server_datadir_bioformatscache" != (omero_server_datadir + "/BioFormatsCache")'
 
 - name: omero server | create omero ManagedRepository
   become: yes


### PR DESCRIPTION
Ideally there would be a property along the lines of `omero.bioformatscache.dir`. Since there isn't this new option `omero_server_datadir_bioformatscache` creates a symlink under `omero.data.dir`

Tag: `2.0.0-m3`