### PR TITLE
Parse latest release from downloads url, upgrade by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,8 @@ Role Variables
 All variables are optional, see `defaults/main.yml` for the full list
 
 OMERO.server version.
-- `omero_server_release`: The OMERO release, e.g. `5.2.2`.
-This defaults to `latest`, but due to the broken registry a proper upgrade check has not been implemented so this will not have the expected effect (it will always attempt to upgrade even if the current server is the latest).
-You are advised to change this to an actual release version.
-- `omero_server_upgrade`: Upgrade OMERO.server if the current version does not match `omero_server_release`.
-  This is a workaround for the inability to check for the latest version when `omero_server_release: latest`.
-  At present this will skip an available upgrade if `False` but in future this will be changed to fail if the currently installed version does not match `omero_server_release`.
+- `omero_server_release`: The OMERO release, e.g. `5.2.2`, default `latest`.
+  You are advised to change this to a release version for production systems, otherwise your server will be automatically upgraded when a new release is made.
 - `omero_server_ice_version`: The ice version.
 
 Database connection parameters and initialisation.
@@ -100,7 +96,6 @@ Example Playbooks
     - hosts: localhost
       roles:
       - openmicroscopy.omero-server
-        omero_server_upgrade: True
         omero_server_release: 5.3.1
         omero_server_dbhost: postgres.example.org
         omero_server_dbuser: db_user

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Role Variables
 All variables are optional, see `defaults/main.yml` for the full list
 
 OMERO.server version.
-- `omero_server_release`: The OMERO release, e.g. `5.2.2`, default `latest`.
-  You are advised to change this to a release version for production systems, otherwise your server will be automatically upgraded when a new release is made.
+- `omero_server_release`: The OMERO release, e.g. `5.2.2`.
+  The default is `present` which will install the latest server if no server is installed, but will not modify an existing server.
+  Use `latest` to automatically upgrade when a new version is released.
 - `omero_server_ice_version`: The ice version.
 
 Database connection parameters and initialisation.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,7 @@
 ---
 # defaults for omero-server
 
-# WARNING: This will currently always attempt to update the server since the registry check is broken
-omero_server_release: latest
+omero_server_release: present
 
 # Ice version
 omero_server_ice_version: "3.6"
@@ -53,7 +52,7 @@ omero_server_systemd_limit_nofile:
 omero_server_systemd_require_network: True
 
 # If non-empty dump the OMERO database to this directory before upgrading
-omero_server_database_backupdir: # "{{ omero_server_basedir }}/backups"
+omero_server_database_backupdir: ""
 
 
 ######################################################################
@@ -105,8 +104,11 @@ omero_server_upgrade: True
 omero_server_checkupgrade_comparator: '<'
 
 
+# _omero_server_new_version is set in tasks/omero-install.yml
+# We can't just use omero_server_release because if it is "present"
+# it needs to be substituted with a value that omego will accept
 omero_server_omego_options: >
-  --release {{ omero_server_release }}
+  --release {{ _omero_server_new_version }}
   --sym {{ omero_server_symlink }}
   --ice {{ omero_server_ice_version }}
   --no-start

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,10 +4,6 @@
 # WARNING: This will currently always attempt to update the server since the registry check is broken
 omero_server_release: latest
 
-# If True and server is already installed then upgrade to the version in
-# omero_server_release, otherwise don't upgrade an existing server.
-omero_server_upgrade: False
-
 # Ice version
 omero_server_ice_version: "3.6"
 
@@ -97,6 +93,11 @@ omero_server_omego_verbosity: "-qq"
 
 # Additional omego aguments passed to upgrade or install
 omero_server_omego_additional_args: ""
+
+# If True and server is already installed then upgrade to the version in
+# omero_server_release, otherwise don't upgrade an existing server.
+# This should not be needed if version are correctly compared.
+omero_server_upgrade: True
 
 # DEVELOPMENT: Operator for comparing current-version against
 # omero_server_release, e.g. '!='. Default is to upgrade when

--- a/molecule.yml
+++ b/molecule.yml
@@ -43,11 +43,12 @@ ansible:
   host_vars:
     omero-server-olddep:
       omero_server_ice_version: "3.5"
-      omero_server_upgrade: False
+      omero_server_release: present
       postgresql_version: "9.4"
 
     omero-server-newdep:
       omero_server_ice_version: "3.6"
+      omero_server_release: latest
       postgresql_version: "9.6"
 
   group_vars:

--- a/molecule.yml
+++ b/molecule.yml
@@ -43,12 +43,12 @@ ansible:
   host_vars:
     omero-server-olddep:
       omero_server_ice_version: "3.5"
+      omero_server_upgrade: False
       postgresql_version: "9.4"
 
     omero-server-newdep:
       omero_server_ice_version: "3.6"
       postgresql_version: "9.6"
-      omero_server_upgrade: True
 
   group_vars:
     docker-hosts:

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,6 +1,18 @@
 ---
 # Install 5.2 on both omero-server-olddep and omero-server-newdep
 - hosts: all
+
+  pre_tasks:
+    # To test the upgrade process without breaking the idempotence check
+    # we need to add a flag so the first omero-server installation is
+    # only run once, otherwise during the second run ansible will attempt
+    # to downgrade a server to 5.2 which will fail due to the lack of a
+    # database downgrade script
+    - name: check whether omero-server has been installed at least once
+      stat:
+        path: /opt/omero/server/OMERO.server
+      register: molecule_test_omero_server_installed_1
+
   roles:
 
     - role: openmicroscopy.postgresql
@@ -20,7 +32,9 @@
           - plate
           - project
           - dataset
+      # This should override host_vars
       omero_server_release: "5.2"
+      when: not molecule_test_omero_server_installed_1.stat.exists
 
   tasks:
     - name: additional config file
@@ -32,10 +46,10 @@
       - restart omero-server
 
 
-# Attempt to upgrade to latest
-# omero_server_upgrade is defined in molecule.yml host_vars so:
-# - omero-server-newdep: upgraded
-# - omero-server-olddep: unchanged
+# Attempt to upgrade
+# omero_server_release is defined in molecule.yml host_vars so:
+# - omero-server-newdep: latest: upgraded
+# - omero-server-olddep: present: unchanged at 5.2
 - hosts: all
   roles:
 
@@ -47,7 +61,6 @@
           - plate
           - project
           - dataset
-      omero_server_release: latest
 
 
 # Additional tasks for setting up tests

--- a/playbook.yml
+++ b/playbook.yml
@@ -32,7 +32,7 @@
       - restart omero-server
 
 
-# Attempt to upgrade to 5.3
+# Attempt to upgrade to latest
 # omero_server_upgrade is defined in molecule.yml host_vars so:
 # - omero-server-newdep: upgraded
 # - omero-server-olddep: unchanged
@@ -47,10 +47,7 @@
           - plate
           - project
           - dataset
-      # Ideally this would be set to the default `latest`, but we don't
-      # have an easy way to check whether the currently installed version
-      # is the latest
-      omero_server_release: "5.3"
+      omero_server_release: latest
 
 
 # Additional tasks for setting up tests

--- a/tasks/omero-install.yml
+++ b/tasks/omero-install.yml
@@ -27,6 +27,49 @@
 # TODO: If server was started by systemd but stopped directly you may end up
 # with a hanging process
 
+# Check whether an upgrade is available since `omego upgrade` always
+# restarts the server
+- name: omero server | get latest downloads url
+  uri:
+    url: https://downloads.openmicroscopy.org/latest/omero
+    method: HEAD
+  register: _omero_server_downloads_latest
+
+# omego supports --release "latest" but not "present"
+# It's easiest to lookup a concrete version and use this for all omego
+# operations instead
+- name: omero server | get latest version
+  set_fact:
+    _omero_server_new_version: "{{
+      (omero_server_release in ('latest', 'present')) | ternary(
+         _omero_server_downloads_latest.url.strip('/').split('/')[-1],
+         omero_server_release
+      )
+  }}"
+
+- name: omero server | checkupgrade
+  set_fact:
+    # Experimentation shows "5.3.2 | version_compare('latest', '<')" is False
+    # so this should work as expected
+    _omero_server_update_needed: "{{
+      omero_server_symlink_st.stat.exists and
+      (omero_server_version.stdout | version_compare(
+         _omero_server_new_version,
+         omero_server_checkupgrade_comparator))
+    }}"
+
+- debug:
+    msg: "Upgrade needed: {{ omero_server_version.stdout }} -> {{ omero_server_release }}"
+  when: _omero_server_update_needed
+
+- name: omero server | set upgrade flag
+  set_fact:
+    _omero_server_execute_upgrade: "{{
+      omero_server_upgrade and
+      _omero_server_update_needed and
+      (omero_server_release != 'present')
+    }}"
+
 - name: omero server | install omero
   become: yes
   become_user: "{{ omero_server_system_user }}"
@@ -43,53 +86,6 @@
   - omero-server rewrite omero-server configuration
   - omero-server restart omero-server
 
-# TODO: Check whether an upgrade is available since `omego upgrade` always
-# restarts the server. It should be possible to use `omero admin checkupgrade`
-# to check, but due to the incomplete registry work it doesn't currently work.
-# For now just compare the current and requested version
-
-- name: omero server | get latest downloads url
-  uri:
-    url: https://downloads.openmicroscopy.org/latest/omero
-    method: HEAD
-  register: _omero_server_downloads_latest
-
-- name: omero server | get latest version
-  set_fact:
-    _omero_server_new_version: >
-      {{
-        (omero_server_release == 'latest') | ternary(
-           _omero_server_downloads_latest.url.strip('/').split('/')[-1],
-           omero_server_release
-        )
-      }}
-
-- name: omero server | checkupgrade
-  set_fact:
-    # Experimentation shows "5.3.2 | version_compare('latest', '<')" is False
-    # so this should work as expected
-    omero_server_update_needed: >
-      {{
-        omero_server_symlink_st.stat.exists and
-        (omero_server_version.stdout | version_compare(
-           _omero_server_new_version,
-           omero_server_checkupgrade_comparator))
-      }}
-
-- debug:
-    msg: "Upgrade needed: {{ omero_server_version.stdout }} -> {{ omero_server_release }}"
-  when: omero_server_update_needed
-
-# TODO: Ideally we'd just use
-# `when: omero_server_upgrade and omero_server_update_needed`
-# but there seems to be a problem with the `omero server | upgrade` task which
-# always runs when `omero_server_upgrade: True` regardless of the value of
-# `omero_server_update_needed`, so use this additional fact as a workaround
-# until it can be investigated further
-- name: omero server | set upgrade flag
-  set_fact:
-    _omero_server_execute_upgrade: "{{ omero_server_upgrade and omero_server_update_needed }}"
-
 # Backup database
 
 - name: omero server | create omero backup directory
@@ -99,7 +95,7 @@
     owner: "{{ omero_server_system_user }}"
     path: "{{ omero_server_database_backupdir }}"
     state: directory
-  when: (omero_server_database_backupdir | default(None)) and omero_server_upgrade and omero_server_update_needed
+  when: (omero_server_database_backupdir | length > 0) and _omero_server_execute_upgrade
 
 - name: omero server | backup database
   become: yes
@@ -111,16 +107,9 @@
     --serverdir {{ omero_server_basedir }}/{{ omero_server_symlink }}
   args:
     chdir: "{{ omero_server_database_backupdir }}"
-  when: (omero_server_database_backupdir | default(None)) and omero_server_upgrade and omero_server_update_needed
+  when: (omero_server_database_backupdir | length > 0) and _omero_server_execute_upgrade
 
 # Upgrade
-# TODO: Currently this silently skips the upgrade if
-# omero_server_update_needed: True and omero_server_upgrade: False
-# since there isn't an easy way to check whether the current version is
-# the same as latest.
-# Once this check is implemented this will change to failing immediately
-# since if you want to pin a particular version you can set
-# omero_server_release: X.Y.Z
 - name: omero server | upgrade
   become: yes
   become_user: "{{ omero_server_system_user }}"
@@ -131,8 +120,6 @@
     {{ omero_server_omego_db_options }}
   args:
     chdir: "{{ omero_server_basedir }}"
-  # I have no idea why testing the variables directly doesn't work:
-  #when: omero_server_upgrade and omero_server_update_needed
   when: _omero_server_execute_upgrade
   notify:
   - omero-server rewrite omero-server configuration

--- a/tasks/omero-install.yml
+++ b/tasks/omero-install.yml
@@ -48,6 +48,22 @@
 # to check, but due to the incomplete registry work it doesn't currently work.
 # For now just compare the current and requested version
 
+- name: omero server | get latest downloads url
+  uri:
+    url: https://downloads.openmicroscopy.org/latest/omero
+    method: HEAD
+  register: _omero_server_downloads_latest
+
+- name: omero server | get latest version
+  set_fact:
+    _omero_server_new_version: >
+      {{
+        (omero_server_release == 'latest') | ternary(
+           _omero_server_downloads_latest.url.strip('/').split('/')[-1],
+           omero_server_release
+        )
+      }}
+
 - name: omero server | checkupgrade
   set_fact:
     # Experimentation shows "5.3.2 | version_compare('latest', '<')" is False
@@ -56,14 +72,9 @@
       {{
         omero_server_symlink_st.stat.exists and
         (omero_server_version.stdout | version_compare(
-           omero_server_release, omero_server_checkupgrade_comparator))
+           _omero_server_new_version,
+           omero_server_checkupgrade_comparator))
       }}
-#  ignore_errors: yes
-#
-#- name: omero server | checkupgrade
-#  set_fact:
-#    omero_server_update_needed: False
-#  when: omero_server_update_needed is not defined
 
 - debug:
     msg: "Upgrade needed: {{ omero_server_version.stdout }} -> {{ omero_server_release }}"

--- a/tests/test_newdep.py
+++ b/tests/test_newdep.py
@@ -10,6 +10,9 @@ OMERO = '/opt/omero/server/OMERO.server/bin/omero'
 def test_omero_version(Command, Sudo):
     with Sudo('data-importer'):
         ver = Command.check_output("%s version" % OMERO)
+    # TODO: This will have to be updated with each major release
+    # These happen infrequently so hard code the version to reduce the
+    # chance of errors being missed elsewhere
     assert re.match('5\.3\.\d+-ice36-', ver)
 
 


### PR DESCRIPTION
This adds the ability to convert `https://downloads.openmicroscopy.org/latest/omero` into a release number. This means for normal installations the value of `omero_server_release` is sufficient to control whether a server is upgraded or not. The `omero_server_upgrade` is therefore changed to `True` and deprecated. The only reason for not removing it at the moment is that the IDR uses a non-standard version system where the version in the URL is not the version reported by the server. This could be remedied by https://trello.com/c/NbdI5wVn/62-release-artifacts-json-scoping since the URL version and the version in  the release-artifacts.json file could be different.