### PR TITLE
Travis fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 OMERO Server
 ============
 
+[![Build Status](https://travis-ci.org/openmicroscopy/ansible-role-omero-server.svg)](https://travis-ci.org/openmicroscopy/ansible-role-omero-server)
+[![Ansible Role](https://img.shields.io/ansible/role/14772.svg)](https://galaxy.ansible.com/openmicroscopy/omero-server/)
+
 Installs and configures OMERO.server.
 
 

--- a/tests/test_newdep.py
+++ b/tests/test_newdep.py
@@ -5,15 +5,16 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     '.molecule/ansible_inventory').get_hosts('omero-server-newdep')
 
 OMERO = '/opt/omero/server/OMERO.server/bin/omero'
+VERSION_PATTERN = re.compile('(\d+)\.(\d+)\.(\d+)-ice36-')
 
 
 def test_omero_version(Command, Sudo):
     with Sudo('data-importer'):
         ver = Command.check_output("%s version" % OMERO)
-    # TODO: This will have to be updated with each major release
-    # These happen infrequently so hard code the version to reduce the
-    # chance of errors being missed elsewhere
-    assert re.match('5\.3\.\d+-ice36-', ver)
+    m = VERSION_PATTERN.match(ver)
+    assert m is not None
+    assert int(m.group(1)) >= 5
+    assert int(m.group(2)) > 2
 
 
 def test_postgres_version(Command):


### PR DESCRIPTION
Fixes #19 

The primary goal of this PR is to fix the currently the failing Travis tests for the omero.server Ansible role since the release of OMERO 5.4.0.

As the scope of the test is primarily to check that a initial OMERO 5.2 server is upgraded, the assertion is modified to test that the new server version is 5.3.0 or later. This should make the check independent of the latest major & minor version numbers of OMERO and reduce the maintenance burden.

Additionally badges are added to the README linking to the CI build and the Galaxy role.