### PR TITLE
Add IPv6 to molecule tests

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -27,6 +27,7 @@
     - role: ansible-role-omero-server
       omero_server_system_managedrepo_group: importer
       omero_server_config_set:
+        Ice.IPv6: "0"
         omero.client.ui.tree.type_order:
           - screen
           - plate
@@ -56,6 +57,7 @@
     - role: ansible-role-omero-server
       omero_server_system_managedrepo_group: importer
       omero_server_config_set:
+        Ice.IPv6: "0"
         omero.client.ui.tree.type_order:
           - screen
           - plate


### PR DESCRIPTION
https://travis-ci.org/openmicroscopy/ome-ansible-molecule-dependencies/builds/319697019
began failing for some reason with only the old dependency not
properly starting. Digging into Blitz-0.log locally, one sees
that Ice is not able to communicate.

This fix could be more cleanly refactored into making the property
a must for all docker tests.

cc: @sbesson @manics 