### PR TITLE
Change default omero-server systemd umask to 0022

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# Changes in Version 3
+
+## Summary of breaking changes
+- `omero_server_system_umask` defaults to `0022`. To restore the old behaviour set it to `0002`.
+
 # Changes in Version 2
 
 ## Summary of breaking changes

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,7 +25,7 @@ omero_server_system_user: omero-server
 #omero_server_system_uid:
 
 # OMERO system user umask
-omero_server_system_umask: "0002"
+omero_server_system_umask: "0022"
 
 # system group for the ManagedRepository
 omero_server_system_managedrepo_group: omero

--- a/playbook.yml
+++ b/playbook.yml
@@ -26,6 +26,7 @@
 
     - role: ansible-role-omero-server
       omero_server_system_managedrepo_group: importer
+      omero_server_system_umask: "0002"
       omero_server_config_set:
         Ice.IPv6: "0"
         omero.client.ui.tree.type_order:
@@ -56,6 +57,7 @@
 
     - role: ansible-role-omero-server
       omero_server_system_managedrepo_group: importer
+      omero_server_system_umask: "0002"
       omero_server_config_set:
         Ice.IPv6: "0"
         omero.client.ui.tree.type_order:


### PR DESCRIPTION
Following discussion on https://github.com/ome/omero-install/pull/173#issuecomment-358233940
> I don't think we specify anywhere assumptions about the omero(-server) user's group, therefore assuming that 0002 is safe on all servers is probably an issue. Without digging deeper, I'd err on the side of making that an addition to the in-place documentation, i.e. a sysadmin is knowingly opening up permissions on a system because of a level of trust granted to the in-place group.

It was decided to default to `0022` everywhere instead of switching other docs/repos to match the `0002` in this repo.

This is a breaking change, tag `3.0.0`