### PR TITLE
Allow a list of additional systemd dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ OMERO.server systemd configuration.
 - `omero_server_systemd_setup`: Create and start the `omero-server` systemd service, default `True`
 - `omero_server_systemd_limit_nofile`: Systemd limit for number of open files (default ignore)
 - `omero_server_systemd_require_network`: Should omero systemd services require a network before starting? Default `True`.
+- `omero_server_systemd_after`: A list of strings with additional service names to appear in systemd unit file "After" statements. Default empty/none.
+- `omero_server_systemd_requires`: A list of strings with additional service names to appear in systemd unit file "Requires" statements. Default empty/none.
 
 - `omero_server_database_backupdir`: Dump the OMERO database to this directory before upgrading, default empty (disabled)
 

--- a/templates/systemd-system-omero-server-service.j2
+++ b/templates/systemd-system-omero-server-service.j2
@@ -10,6 +10,10 @@ After=postgresql-9.6.service
 Requires=network.service
 {% endif %}
 After=network.service
+{% for value in ((omero_server_systemd_after | default({})) | sort) %}After={{ value }}
+{% endfor %}
+{% for value in ((omero_server_systemd_requires | default({})) | sort) %}Requires={{ value }}
+{% endfor %}
 
 [Service]
 User={{ omero_server_system_user }}


### PR DESCRIPTION
... /requirements for e.g GPFS or other storage services

Testing: 

An example test would be to take the ansible public user example like: https://github.com/ome/ansible-examples-omero/tree/master/public-user

And apply the following diff:

```
     - role: openmicroscopy.omero-server
       omero_server_release: 5.4.1
+      omero_server_systemd_limit_nofile: 16384
+      omero_server_systemd_limit_nofile: 16384
+      omero_server_systemd_after:
+      - gpfs.service
+      - another.service
```

Then check that the systemd unit file generate includes:

(`/etc/systemd/system/omero-server.service`)
```
After=another.service
After=gpfs.service
```

Ref docs: https://www.freedesktop.org/software/systemd/man/systemd.unit.html#%5BUnit%5D%20Section%20Options