### PR TITLE
Fix failing import test following Java release

### DIFF
--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -31,34 +31,6 @@ def test_omero_server_config(Command, Sudo, key, value):
     assert cfg == value
 
 
-def test_inplace_import(Command, File, Sudo):
-    with Sudo('data-importer'):
-        outimport = Command.check_output(
-            '%s %s import -- --transfer=ln_s /data/import/test.fake' %
-            (OMERO, OMERO_LOGIN))
-
-    try:
-        # 5.3 uses a new output format Image:ID
-        imageid = int(outimport.split(':', 1)[1])
-    except IndexError:
-        imageid = int(outimport)
-    assert imageid
-
-    query = ('SELECT concat(ofile.path, ofile.name) '
-             'FROM FilesetEntry AS fse '
-             'JOIN fse.fileset AS fileset '
-             'JOIN fse.originalFile AS ofile '
-             'JOIN fileset.images AS image '
-             'WHERE image.id = %d' % imageid)
-    with Sudo('data-importer'):
-        outhql = Command.check_output(
-            '%s %s hql -q --style plain "%s"' % (OMERO, OMERO_LOGIN, query))
-
-    f = File('/OMERO/ManagedRepository/%s' % outhql.split(',', 1)[1])
-    assert f.is_symlink
-    assert f.linked_to == '/data/import/test.fake'
-
-
 def test_omero_datadir(File):
     d = File('/OMERO')
     assert d.is_directory

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,32 @@
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('omero-server-newdep')
+
+OMERO = '/opt/omero/server/OMERO.server/bin/omero'
+OMERO_LOGIN = '-C -s localhost -u root -w omero'
+
+
+def test_inplace_import(Command, File, Sudo):
+    fake_file = '/data/import/test.fake'
+    with Sudo('data-importer'):
+        outimport = Command.check_output(
+            '%s %s import --skip=upgrade --transfer=ln_s %s' %
+            (OMERO, OMERO_LOGIN, fake_file))
+
+    imageid = int(outimport.split(':', 1)[1])
+    assert imageid
+
+    query = ('SELECT concat(ofile.path, ofile.name) '
+             'FROM FilesetEntry AS fse '
+             'JOIN fse.fileset AS fileset '
+             'JOIN fse.originalFile AS ofile '
+             'JOIN fileset.images AS image '
+             'WHERE image.id = %d' % imageid)
+    with Sudo('data-importer'):
+        outhql = Command.check_output(
+            '%s %s hql -q --style plain "%s"' % (OMERO, OMERO_LOGIN, query))
+
+    f = File('/OMERO/ManagedRepository/%s' % outhql.split(',', 1)[1])
+    assert f.is_symlink
+    assert f.linked_to == fake_file


### PR DESCRIPTION
The Java security changes disabling anonymous cyphers have now been propagated to the openjdk and package managers and causes CLI imports via the CLI to fail with a `SSLHandshakeException` - see https://travis-ci.org/ome/ansible-roles/jobs/514734263

With OMERO 5.4.10, the workaround is to skip the upgrade check at import time. This means the role import tests can no longer be run on older servers. It is thus moved to a separate test file and restricted to the test hosts upgraded to the latest version.