### PR TITLE
Remove unstable section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,21 +60,6 @@ OMERO.server systemd configuration.
 - `omero_server_database_backupdir`: Dump the OMERO database to this directory before upgrading, default empty (disabled)
 
 
-Unstable features
------------------
-
-Variables :
-- `omero_server_datadir_chown`: Recursively set the owner on the OMERO data directory, use if the directory has been copied with an incorrect owner, default `False`
-- `omero_server_datadir_bioformatscache`: OMERO BioFormatsCache directory, a symlink `{omero_server_datadir}/BioFormatsCache` will be created if not the default.
-  Directory paths must not have a trailing `/`.
-- `omero_server_database_manage`: Initialise or upgrade the OMERO database if required, default `True`, if `False` the database will not be modified and all `omero_server_db*` will be ignored (`omero.db.*` OMERO configuration parameters will not be updated with the corresponding `omero_server_db*` values)
-- `omero_server_datadir_manage`: Initialise of modify the top level of OMERO data directories, deafult `True`, if `False` no data directories will be created or modified, and the `omero.data.dir` configuration parameter will not be set
-- `omero_server_systemd_start`: Automatically enable and start/restart systemd omero-server service, default `True`.
-  This is intended for use in server images where installation may be separate from configuration and execution.
-- `omero_server_always_reset_config`: Clear the existing configuration before regenerating, default `True`.
-
-
-
 Configuring OMERO.server
 ------------------------
 


### PR DESCRIPTION
Unstable/expert parameters are already documented in `defaults/main.yml`.
In line with other roles these parameters are not documented in the README.